### PR TITLE
fix: correct glob for command file discovery

### DIFF
--- a/src/Classes/CommandHandler.js
+++ b/src/Classes/CommandHandler.js
@@ -19,7 +19,7 @@ class CommandHandler {
     load(isShowLog = true) {
         if (isShowLog) this.consolefy.group("Command Handler Load");
 
-        const files = globSync("**/*.{js}", {
+        const files = globSync("**/*.js", {
             cwd: this._path,
             nodir: true,
             absolute: true


### PR DESCRIPTION
Replace **/.{js} with **/.js to avoid empty results from globSync.